### PR TITLE
Move host selection logic in vsphere.rb

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -21,9 +21,6 @@ module Vmpooler
 
       # Our thread-tracker object
       $threads = {}
-
-      # Host tracking object
-      $provider_hosts = {}
     end
 
     def config
@@ -461,77 +458,6 @@ module Vmpooler
       end
     end
 
-    def get_provider_name(pool_name, config = $config)
-      pool = config[:pools].select { |p| p['name'] == pool_name }[0]
-      provider_name = pool['provider'] if pool.key?('provider')
-      provider_name = config[:providers].first[0].to_s if provider_name.nil? and config.key?(:providers)
-      provider_name = 'default' if provider_name.nil?
-      provider_name
-    end
-
-    def get_cluster(pool_name)
-      default_cluster = $config[:config]['clone_target'] if $config[:config].key?('clone_target')
-      default_datacenter = $config[:config]['datacenter'] if $config[:config].key?('datacenter')
-      pool = $config[:pools].select { |p| p['name'] == pool_name }[0]
-      cluster = pool['clone_target'] if pool.key?('clone_target')
-      cluster = default_cluster if cluster.nil?
-      datacenter = pool['datacenter'] if pool.key?('datacenter')
-      datacenter = default_datacenter if datacenter.nil?
-      return if cluster.nil?
-      return if datacenter.nil?
-      { 'cluster' => cluster, 'datacenter' => datacenter }
-    end
-
-    def select_hosts(pool_name, provider, provider_name, cluster, datacenter, percentage)
-      $provider_hosts[provider_name] = {} unless $provider_hosts.key?(provider_name)
-      $provider_hosts[provider_name][datacenter] = {} unless $provider_hosts[provider_name].key?(datacenter)
-      $provider_hosts[provider_name][datacenter][cluster] = {} unless $provider_hosts[provider_name][datacenter].key?(cluster)
-      $provider_hosts[provider_name][datacenter][cluster]['checking'] = true
-      hosts_hash = provider.select_target_hosts(cluster, datacenter, percentage)
-      $provider_hosts[provider_name][datacenter][cluster] = hosts_hash
-      $provider_hosts[provider_name][datacenter][cluster]['check_time_finished'] = Time.now
-    end
-
-    def run_select_hosts(provider, pool_name, provider_name, cluster, datacenter, max_age, percentage)
-      now = Time.now
-      if $provider_hosts.key?(provider_name) and $provider_hosts[provider_name].key?(datacenter) and $provider_hosts[provider_name][datacenter].key?(cluster) and $provider_hosts[provider_name][datacenter][cluster].key?('checking')
-        wait_for_host_selection(pool_name, provider_name, cluster, datacenter)
-      elsif $provider_hosts.key?(provider_name) and $provider_hosts[provider_name].key?(datacenter) and $provider_hosts[provider_name][datacenter].key?(cluster) and $provider_hosts[provider_name][datacenter][cluster].key?('check_time_finished')
-        select_hosts(pool_name, provider, provider_name, cluster, datacenter, percentage) if now - $provider_hosts[provider_name][datacenter][cluster]['check_time_finished'] > max_age
-      else
-        select_hosts(pool_name, provider, provider_name, cluster, datacenter, percentage)
-      end
-    end
-
-    def wait_for_host_selection(pool_name, provider_name, cluster, datacenter, maxloop = 0, loop_delay = 5, max_age = 60)
-      loop_count = 1
-      until $provider_hosts[provider_name][datacenter][cluster].key?('check_time_finished')
-        sleep(loop_delay)
-        unless maxloop.zero?
-          break if loop_count >= maxloop
-          loop_count += 1
-        end
-      end
-      return unless $provider_hosts[provider_name][datacenter][cluster].key?('check_time_finished')
-      loop_count = 1
-      while Time.now - $provider_hosts[provider_name][datacenter][cluster]['check_time_finished'] > max_age
-        sleep(loop_delay)
-        unless maxloop.zero?
-          break if loop_count >= maxloop
-          loop_count += 1
-        end
-      end
-    end
-
-    def select_next_host(provider_name, datacenter, cluster, architecture)
-      provider_hosts = $provider_hosts
-      host = provider_hosts[provider_name][datacenter][cluster]['architectures'][architecture][0]
-      return if host.nil?
-      provider_hosts[provider_name][datacenter][cluster]['architectures'][architecture].delete(host)
-      provider_hosts[provider_name][datacenter][cluster]['architectures'][architecture] << host
-      host
-    end
-
     def migration_limit(migration_limit)
       # Returns migration_limit setting when enabled
       return false if migration_limit == 0 || !migration_limit # rubocop:disable Style/NumericPredicate
@@ -552,23 +478,22 @@ module Vmpooler
     def _migrate_vm(vm_name, pool_name, provider)
       $redis.srem("vmpooler__migrating__#{pool_name}", vm_name)
 
-      provider_name = get_provider_name(pool_name)
       vm = provider.get_vm_details(pool_name, vm_name)
-      raise('Unable to determine which host the VM is running on') if vm['host'].nil?
+      raise('Unable to determine which host the VM is running on') if vm.nil? or vm['host'].nil?
       migration_limit = migration_limit $config[:config]['migration_limit']
       migration_count = $redis.scard('vmpooler__migration')
 
       if migration_limit
-        max_age = 60
-        percentage_of_hosts_below_average = 100
-        run_select_hosts(provider, pool_name, provider_name, vm['cluster'], vm['datacenter'], max_age, percentage_of_hosts_below_average)
         if migration_count >= migration_limit
           $logger.log('s', "[ ] [#{pool_name}] '#{vm_name}' is running on #{vm['host']}. No migration will be evaluated since the migration_limit has been reached")
-        elsif $provider_hosts[provider_name][vm['datacenter']][vm['cluster']]['architectures'][vm['architecture']].include?(vm['host'])
+          return
+        end
+        provider.run_select_hosts(pool_name, provider.provider_hosts)
+        if provider.vm_in_target?(pool_name, vm['host'], vm['architecture'], provider.provider_hosts)
           $logger.log('s', "[ ] [#{pool_name}] No migration required for '#{vm_name}' running on #{vm['host']}")
         else
           $redis.sadd('vmpooler__migration', vm_name)
-          target_host_name = select_next_host(provider_name, vm['datacenter'], vm['cluster'], vm['architecture'])
+          target_host_name = provider.select_next_host(pool_name, vm['architecture'], provider.provider_hosts)
           finish = migrate_vm_and_record_timing(vm_name, pool_name, vm['host'], target_host_name, provider)
           $logger.log('s', "[>] [#{pool_name}] '#{vm_name}' migrated from #{vm['host']} to #{target_host_name} in #{finish} seconds")
           remove_vmpooler_migration_vm(pool_name, vm_name)

--- a/lib/vmpooler/providers/base.rb
+++ b/lib/vmpooler/providers/base.rb
@@ -11,12 +11,15 @@ module Vmpooler
         attr_reader :metrics
         # Provider options passed in during initialization
         attr_reader :provider_options
+        # Hash for tracking hosts for deployment
+        attr_reader :provider_hosts
 
         def initialize(config, logger, metrics, name, options)
           @config = config
           @logger = logger
           @metrics = metrics
           @provider_name = name
+          @provider_hosts = {}
 
           # Ensure that there is not a nil provider configuration
           @config[:providers] = {} if @config[:providers].nil?

--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -1474,383 +1474,6 @@ EOT
   end
 
 
-  describe '#get_provider_name' do
-    context 'with a single provider and no pool specified provider' do
-      let(:config) {
-        YAML.load(<<-EOT
----
-:providers:
-  :vc1:
-    server: 'server1'
-:pools:
-  - name: #{pool}
-EOT
-        )
-      }
-      it 'returns the name of the configured provider' do
-        expect(subject.get_provider_name(pool, config)).to eq('vc1')
-      end
-    end
-
-    context 'with no providers configured' do
-      let(:config) {
-        YAML.load(<<-EOT
----
-:pools:
-  - name: #{pool}
-EOT
-        )
-      }
-
-      it 'should return default' do
-        expect(subject.get_provider_name(pool, config)).to eq('default')
-      end
-    end
-
-    context 'with a provider configured for the pool' do
-      let(:config) {
-        YAML.load(<<-EOT
----
-:providers:
-  :vc1:
-    server: 'server1'
-  :vc2:
-    server: 'server2'
-:pools:
-  - name: #{pool}
-    provider: 'vc2'
-EOT
-        )
-      }
-
-      it 'should return the configured provider name' do
-        expect(subject.get_provider_name(pool, config)).to eq('vc2')
-      end
-    end
-  end
-
-
-  describe '#get_cluster' do
-    let(:cluster) { 'cluster1' }
-    let(:datacenter) { 'dc1' }
-    let(:cluster_dc) { { 'cluster' => cluster, 'datacenter' => datacenter } }
-
-    context 'defaults configured' do
-      let(:config) {
-        YAML.load(<<-EOT
----
-:config:
-  clone_target: 'cluster1'
-  datacenter: 'dc1'
-:pools:
-  - name: #{pool}
-EOT
-        )
-      }
-
-      it 'should return the default cluster and dc' do
-        expect(subject.get_cluster(pool)).to eq(cluster_dc)
-      end
-    end
-
-    context 'with clone_target specified for pool' do
-      let(:config) {
-        YAML.load(<<-EOT
----
-:config:
-  datacenter: 'dc1'
-:pools:
-  - name: #{pool}
-    clone_target: 'cluster1'
-EOT
-        )
-      }
-
-      it 'should return the configured cluster and dc' do
-        expect(subject.get_cluster(pool)).to eq(cluster_dc)
-      end
-    end
-
-    context 'with clone_target and datacenter specified for pool' do
-      let(:config) {
-        YAML.load(<<-EOT
----
-:config:
-  task_limit: 10
-:pools:
-  - name: #{pool}
-    clone_target: 'cluster1'
-    datacenter: 'dc1'
-EOT
-        )
-      }
-      before(:each) do
-        $config = config
-      end
-      it 'should return the configured cluster and dc' do
-        expect(subject.get_cluster(pool)).to eq(cluster_dc)
-      end
-    end
-  end
-
-
-  describe '#select_hosts' do
-
-    let(:config) {
-      YAML.load(<<-EOT
----
-:config:
-  task_limit: 10
-  clone_target: 'cluster1'
-:pools:
-  - name: #{pool}
-    size: 10
-EOT
-      )
-    }
-    let(:provider_name) { 'default' }
-    let(:datacenter) { 'dc1' }
-    let(:cluster) { 'cluster1' }
-    let(:percentage) { 100 }
-    let(:architecture) { 'v3' }
-    let(:hosts_hash) {
-      {
-        'hosts' => [ 'host1' ],
-        'architectures' => { architecture => ['host1'] }
-      }
-    }
-    let(:provider_hosts) {
-      {
-        provider_name => {
-          datacenter => {
-            cluster => hosts_hash
-          }
-        }
-      }
-    }
-
-    it 'should populate $provider_hosts' do
-      expect(provider).to receive(:select_target_hosts).with(cluster, datacenter, percentage).and_return(hosts_hash)
-      subject.select_hosts(pool, provider, provider_name, cluster, datacenter, percentage)
-      expect($provider_hosts).to eq(provider_hosts)
-    end
-  end
-
-  describe '#run_select_hosts' do
-    let(:config) {
-      YAML.load(<<-EOT
----
-:config:
-  task_limit: 10
-  clone_target: 'cluster1'
-:pools:
-  - name: #{pool}
-    size: 10
-EOT
-      )
-    }
-    let(:provider_hosts) {
-      {
-        provider_name => {
-          datacenter => {
-            cluster => {
-              'check_time_finished' => Time.now,
-              'hosts' => [ 'host1' ],
-              'architectures' => { 'v3' => ['host1'] },
-            }
-          }
-        }
-      }
-    }
-    let(:provider) { double('provider') }
-    let(:pool_object) { config[:pools][0] }
-    let(:pool_name) { pool_object['name'] }
-    let(:maxage) { 60 }
-    let(:cluster) { 'cluster1' }
-    let(:datacenter) { 'dc1' }
-    let(:provider_name) { 'default' }
-    let(:maxage) { 60 }
-    let(:percentage_of_hosts_below_average) { 100 }
-    # A wrapper to ensure select_hosts is not run more than once, and results are present
-    before(:each) do
-      expect(subject).not_to be_nil
-      $provider_hosts = provider_hosts
-    end
-
-    context '$provider_hosts has key checking' do
-      before(:each) do
-        $provider_hosts[provider_name][datacenter][cluster]['checking'] = true
-      end
-
-      it 'runs wait_for_host_selection' do
-        expect(subject).to receive(:wait_for_host_selection).with(pool_name, provider_name, cluster, datacenter)
-        subject.run_select_hosts(provider, pool_name, provider_name, cluster, datacenter, maxage, percentage_of_hosts_below_average)
-      end
-
-    end
-
-    context '$provider_hosts has check_time_finished key and is 100 seconds old' do
-
-      before(:each) do
-        $provider_hosts[provider_name][datacenter][cluster]['check_time_finished'] = Time.now - 100
-      end
-
-      it 'runs select_hosts' do
-        expect(provider).to receive(:select_target_hosts).with(cluster, datacenter, percentage_of_hosts_below_average).and_return(provider_hosts[provider_name][datacenter][cluster])
-
-        subject.run_select_hosts(provider, pool_name, provider_name, cluster, datacenter, maxage, percentage_of_hosts_below_average)
-      end
-    end
-
-    context '$provider_hosts has check_time_finished key 10 seconds old' do
-      before(:each) do
-        $provider_hosts = provider_hosts
-        $provider_hosts['check_time_finished'] = Time.now - 10
-      end
-
-      it 'does not run select_hosts' do
-        expect(subject).not_to receive(:select_hosts)
-
-        subject.run_select_hosts(provider, pool_name, provider_name, cluster, datacenter, maxage, percentage_of_hosts_below_average)
-      end
-    end
-
-    context '$provider_hosts does not have key check_time_finished' do
-      let(:provider_hosts) { { } }
-
-      before(:each) do
-        $provider_hosts = provider_hosts
-      end
-
-      it 'runs select_hosts' do
-        expect(subject).to receive(:select_hosts).with(provider).with(pool_name, provider, provider_name, cluster, datacenter, percentage_of_hosts_below_average)
-
-        subject.run_select_hosts(provider, pool_name, provider_name, cluster, datacenter, maxage, percentage_of_hosts_below_average)
-      end
-    end
-  end
-
-
-  describe '#wait_for_host_selection' do
-    let(:loop_delay) { 0 }
-    let(:max_age) { 60 }
-    let(:provider_name) { 'default' }
-    let(:cluster) { 'cluster1' }
-    let(:datacenter) { 'dc1' }
-    let(:maxloop) { 1 }
-    let(:provider_hosts) {
-      {
-        provider_name => {
-          datacenter => {
-            cluster => {
-            }
-          }
-        }
-      }
-    }
-
-    before(:each) do
-      expect(subject).not_to be_nil
-      $provider_hosts = provider_hosts
-    end
-
-    context 'when provider_hosts does not have key check_time_finished and maxloop is one' do
-
-      it 'sleeps for loop_delay once' do
-        expect(subject).to receive(:sleep).with(loop_delay).exactly(maxloop).times
-        expect($provider_hosts).to eq(provider_hosts)
-        expect($provider_hosts).to have_key(provider_name)
-        expect(provider_hosts[provider_name]).to have_key(datacenter)
-
-        subject.wait_for_host_selection(pool, provider_name, cluster, datacenter, maxloop, loop_delay, max_age)
-      end
-    end
-
-    context 'when provider_hosts does not have key check_time_finished and maxloop is two' do
-      let(:maxloop) { 2 }
-
-      it 'sleeps for loop_delay two times' do
-        expect(subject).to receive(:sleep).with(loop_delay).exactly(maxloop).times
-
-        subject.wait_for_host_selection(pool, provider_name, cluster, datacenter, maxloop, loop_delay, max_age)
-      end
-    end
-
-    context 'when $provider_hosts has key check_time_finished and age is greater than max_age' do
-      let(:provider_hosts) {
-        {
-          provider_name => {
-            datacenter => {
-              cluster => {
-                'check_time_finished' => Time.now - 100
-              }
-            }
-          }
-        }
-      }
-
-      before(:each) do
-        $provider_hosts = provider_hosts
-      end
-
-      it 'sleeps for loop_delay once' do
-        expect(subject).to receive(:sleep).with(loop_delay).exactly(maxloop).times
-
-        subject.wait_for_host_selection(pool, provider_name, cluster, datacenter, maxloop, loop_delay, max_age)
-      end
-    end
-  end
-
-
-  describe '#select_next_host' do
-
-    let(:hosts_hash) { }
-    let(:cluster) { 'cluster1' }
-    let(:architecture) { 'v3' }
-    let(:target_host) { 'host1' }
-    let(:provider_name) { 'default' }
-    let(:datacenter) { 'dc1' }
-    let(:provider_hosts) {
-      {
-        provider_name => {
-          datacenter => {
-            cluster => {
-              'check_time_finished' => Time.now,
-              'architectures' => { architecture => ['host1', 'host2'] }
-            }
-          }
-        }
-      }
-    }
-    before(:each) do
-      expect(subject).not_to be_nil
-      $provider_hosts = provider_hosts
-    end
-
-    context 'with a list of hosts available' do
-
-      it 'returns the first host from the target cluster and architecture list' do
-        expect(subject.select_next_host(provider_name, datacenter, cluster, architecture)).to eq(target_host)
-      end
-
-      it 'return the second host on the second call to select_next_host' do
-        expect(subject.select_next_host(provider_name, datacenter, cluster, architecture)).to eq(target_host)
-        expect(subject.select_next_host(provider_name, datacenter, cluster, architecture)).to eq('host2')
-      end
-    end
-
-    context 'with no hosts available' do
-      before(:each) do
-        $provider_hosts[provider_name][datacenter][cluster]['architectures'][architecture] = []
-      end
-      it 'returns nil' do
-        expect(subject.select_next_host(provider_name, datacenter, cluster, architecture)).to be_nil
-      end
-    end
-
-  end
-
-
   describe '#migration_limit' do
     # This is a little confusing.  Is this supposed to return a boolean
     # or integer type?
@@ -1885,19 +1508,6 @@ EOT
       subject.migrate_vm(vm, pool, provider)
     end
 
-      let(:provider_hosts) {
-        {
-          'check_time_finished' => Time.now,
-          'clusters' => {
-            'cluster1' => {
-              'hosts' => ['host1'],
-              'architectures' => { 'v3' => ['host1'] },
-              'all_hosts' => ['host1']
-            }
-          }
-        }
-      }
-
     context 'When an error is raised' do
       before(:each) do
         expect(subject).to receive(:_migrate_vm).with(vm, pool, provider).and_raise('MockError')
@@ -1919,53 +1529,43 @@ EOT
   end
 
   describe "#_migrate_vm" do
-    let(:vm_parent_hostname) { 'host1' }
-    let(:cluster_name) { 'cluster1' }
-    let(:host_architecture) { 'v3' }
-    let(:datacenter) { 'dc1' }
-    let(:provider_name) { 'default' }
-    let(:percentage) { 100 }
+    let(:vm_parent_hostname) { 'parent1' }
+    let(:vm_new_hostname) { 'new_hostname' }
+    let(:architecture) { 'v3' }
+    let(:vm_details) {
+      {
+        'host' => vm_parent_hostname,
+        'architecture' =>architecture
+      }
+    }
+    let(:provider_hosts) {
+      {
+        'dc1_cluster1' => {
+          'architectures' => {
+            architecture => [vm_new_hostname]
+          }
+        }
+      }
+    }
+
     let(:config) {
       YAML.load(<<-EOT
 ---
 :config:
   migration_limit: 5
-  clone_target: 'cluster1'
-:pools:
-  - name: #{pool}
 EOT
       )
-    }
-    let(:provider_hosts) {
-      {
-        provider_name => {
-          datacenter => {
-            cluster_name => {
-              'check_time_finished' => Time.now,
-              'hosts' => [vm_parent_hostname],
-              'architectures' => { host_architecture => [vm_parent_hostname] }
-            }
-          }
-        }
-      }
-    }
-    let(:vm_data) {
-      {
-       'host' => vm_parent_hostname,
-       'cluster' => cluster_name,
-       'architecture' => host_architecture,
-       'datacenter' => datacenter
-      }
     }
 
     before(:each) do
       expect(subject).not_to be_nil
-      allow(provider).to receive(:get_vm_details).with(pool, vm).and_return(vm_data)
+      #expect(provider).to receive(:get_vm_details).with(pool, vm).and_return(vm_details)
     end
 
     context 'when an error occurs trying to retrieve the current host' do
       before(:each) do
         expect(provider).to receive(:get_vm_details).with(pool, vm).and_raise(RuntimeError,'MockError')
+        #expect(provider).to receive(:get_vm_details).with(pool, vm).and_return(vm_details)
       end
 
       it 'should raise an error' do
@@ -1974,18 +1574,8 @@ EOT
     end
 
     context 'when the current host can not be determined' do
-      let(:vm_data) {
-        {
-         'host' => nil,
-         'cluster' => cluster_name,
-         'architecture' => host_architecture,
-         'datacenter' => datacenter
-        }
-      }
-
       before(:each) do
-        $provider_hosts = provider_hosts
-        allow(provider).to receive(:get_vm_details).with(pool, vm).and_return(vm_data)
+        expect(provider).to receive(:get_vm_details).with(pool, vm).and_return(nil)
       end
 
       it 'should raise an error' do
@@ -1995,8 +1585,8 @@ EOT
 
     context 'when VM exists but migration is disabled' do
       before(:each) do
+        expect(provider).to receive(:get_vm_details).with(pool, vm).and_return(vm_details)
         create_migrating_vm(vm, pool)
-        expect(provider).to receive(:get_vm_details).with(pool, vm).and_return(vm_data)
       end
 
       [-1,-32768,false,0].each do |testvalue|
@@ -2006,7 +1596,8 @@ EOT
           subject._migrate_vm(vm, pool, provider)
         end
 
-        it "should not remove the VM from vmpooler__migrating queue in redis if the migration limit is #{testvalue}" do
+        it "should remove the VM from vmpooler__migrating queue in redis if the migration limit is #{testvalue}" do
+          redis.sadd("vmpooler__migrating__#{pool}", vm)
           config[:config]['migration_limit'] = testvalue
 
           expect(redis.sismember("vmpooler__migrating__#{pool}",vm)).to be_truthy
@@ -2018,9 +1609,6 @@ EOT
 
     context 'when VM exists but migration limit is reached' do
       before(:each) do
-        $provider_hosts = provider_hosts
-        expect(provider).to receive(:select_target_hosts).with(cluster_name, datacenter, percentage).and_return($provider_hosts[provider_name][datacenter][cluster_name])
-        expect(provider).to receive(:get_vm_details).with(pool, vm).and_return(vm_data)
 
         create_migrating_vm(vm, pool)
         redis.sadd('vmpooler__migration', 'fakevm1')
@@ -2028,6 +1616,7 @@ EOT
         redis.sadd('vmpooler__migration', 'fakevm3')
         redis.sadd('vmpooler__migration', 'fakevm4')
         redis.sadd('vmpooler__migration', 'fakevm5')
+        expect(provider).to receive(:get_vm_details).with(pool, vm).and_return(vm_details)
       end
 
       it "should not migrate a VM if the migration limit is reached" do
@@ -2043,22 +1632,18 @@ EOT
     end
 
     context 'when VM exists but migration limit is not yet reached' do
-
       before(:each) do
         create_migrating_vm(vm, pool)
-        expect(provider).to receive(:get_vm_details).with(pool, vm).and_return(vm_data)
         redis.sadd('vmpooler__migration', 'fakevm1')
         redis.sadd('vmpooler__migration', 'fakevm2')
       end
 
-      context 'and current host is within the list of available targets' do
-        let(:target_hosts) { ['host1'] }
-        #
+      context 'and host to migrate to is the same as the current host' do
+        let(:architecture) { 'v3' }
         before(:each) do
-          $provider_hosts = provider_hosts
-          expect(provider).to receive(:select_target_hosts).with(cluster_name, datacenter, percentage).and_return($provider_hosts[provider_name][datacenter][cluster_name])
-
-          #expect(subject).to receive(:host_in_targets?).with(vm_parent_hostname, target_hosts).and_return(true)
+          expect(provider).to receive(:get_vm_details).with(pool, vm).and_return(vm_details)
+          expect(provider).to receive(:run_select_hosts)
+          expect(provider).to receive(:vm_in_target?).and_return(true)
         end
 
         it "should not migrate the VM" do
@@ -2085,19 +1670,11 @@ EOT
       end
 
       context 'and host to migrate to different to the current host' do
-        let(:vm_new_hostname) { 'host1' }
-        let(:vm_parent_hostname) { 'host2' }
-        let(:dc) { 'dc1' }
-        let(:host_architecture) { 'v3' }
-        let(:hosts_hash) {
-          {
-            'hosts' => [ 'host1' ],
-            'architectures' => { 'v3' => ['host1'] },
-          }
-        }
         before(:each) do
-          $provider_hosts = provider_hosts
-          expect(provider).to receive(:select_target_hosts).with(cluster_name, dc, percentage).and_return(hosts_hash)
+          expect(provider).to receive(:get_vm_details).with(pool, vm).and_return(vm_details)
+          expect(provider).to receive(:run_select_hosts)
+          expect(provider).to receive(:vm_in_target?).and_return(false)
+          expect(provider).to receive(:select_next_host).and_return(vm_new_hostname)
           expect(subject).to receive(:migrate_vm_and_record_timing).with(vm, pool, vm_parent_hostname, vm_new_hostname, provider).and_return('1.00')
         end
 

--- a/spec/unit/providers/vsphere_spec.rb
+++ b/spec/unit/providers/vsphere_spec.rb
@@ -1968,71 +1968,71 @@ EOT
     end
   end
 
-  describe '#get_vm_cluster' do
-    it 'returns the name of a vm_object parent cluster' do
-
-    end
-
-    it 'returns nil when cluster_name is not found for the vm_object' do
-
-    end
-  end
-
-  describe '#get_vm_cpu_architecture' do
-    it 'returns the architecture of a vm_object parent host' do
-
-    end
-  end
-
-  describe '#select_target_hosts' do
-    it 'returns a hash of the least used hosts by cluster and architecture' do
-
-    end
-
-    it 'raises an error if the target cluster does not exist' do
-
-    end
-
-    it 'finds a cluster without a specified datacenter' do
-
-    end
-
-    it 'finds a cluster with a datacenter specified' do
-
-    end
-  end
-
-  describe '#get_average_cluster_utilization' do
-    it 'returns the average utilization for a given set of host utilizations assuming the first member of the list for each host is the utilization value' do
-
-    end
-  end
-
-  describe '#build_compatible_hosts_lists' do
-    it 'returns a hash of target host architecture versions containing lists of target hosts' do
-
-    end
-  end
-
-  describe '#select_least_used_hosts' do
-    it 'returns the percentage specified of the least used hosts in the cluster determined by selecting from less than or equal to average cluster utilization' do
-
-    end
-
-    it 'raises an error when the provided hosts list is empty' do
-
-    end
-  end
-
-  describe '#find_host_by_dnsname' do
-    it 'returns a host object when a matching host is found by dnsname in connection.searchIndex' do
-
-    end
-
-    it 'returns nil when the host object is not found by dnsname in connection.searchIndex' do
-
-    end
-  end
+# describe '#get_vm_cluster' do
+#   it 'returns the name of a vm_object parent cluster' do
+#
+#   end
+#
+#   it 'returns nil when cluster_name is not found for the vm_object' do
+#
+#   end
+# end
+#
+# describe '#get_vm_cpu_architecture' do
+#   it 'returns the architecture of a vm_object parent host' do
+#
+#   end
+# end
+#
+# describe '#select_target_hosts' do
+#   it 'returns a hash of the least used hosts by cluster and architecture' do
+#
+#   end
+#
+#   it 'raises an error if the target cluster does not exist' do
+#
+#   end
+#
+#   it 'finds a cluster without a specified datacenter' do
+#
+#   end
+#
+#   it 'finds a cluster with a datacenter specified' do
+#
+#   end
+# end
+#
+# describe '#get_average_cluster_utilization' do
+#   it 'returns the average utilization for a given set of host utilizations assuming the first member of the list for each host is the utilization value' do
+#
+#   end
+# end
+#
+# describe '#build_compatible_hosts_lists' do
+#   it 'returns a hash of target host architecture versions containing lists of target hosts' do
+#
+#   end
+# end
+#
+# describe '#select_least_used_hosts' do
+#   it 'returns the percentage specified of the least used hosts in the cluster determined by selecting from less than or equal to average cluster utilization' do
+#
+#   end
+#
+#   it 'raises an error when the provided hosts list is empty' do
+#
+#   end
+# end
+#
+# describe '#find_host_by_dnsname' do
+#   it 'returns a host object when a matching host is found by dnsname in connection.searchIndex' do
+#
+#   end
+#
+#   it 'returns nil when the host object is not found by dnsname in connection.searchIndex' do
+#
+#   end
+# end
 
   describe '#find_least_used_hosts' do
     let(:cluster_name) { 'cluster' }


### PR DESCRIPTION
This commit updates vsphere.rb to contain updates to host selection
logic there. Without this change changes to host selection that are
vsphere specific are polluting pool_manager which impacts the providers
concept being pluggable. Additionally, provider_hosts is moved to the
provider base class so it can be accessible on a per provider basis.