### PR TITLE
Fixing method remove_excess_vms

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,8 +1,17 @@
-### API
+# Table of contents
+1. [API](#API)
+2. [Token operations](#token)
+3. [VM operations](#vmops)
+4. [Add disks](#adddisks)
+5. [VM snapshots](#vmsnapshots)
+6. [Status and metrics](#statusmetrics)
+7. [Pool configuration changes](#poolconfig)
+
+### API <a name="API"></a>
 
 vmpooler provides a REST API for VM management.  The following examples use `curl` for communication.
 
-#### Token operations
+#### Token operations <a name="token"></a>
 
 Token-based authentication can be used when requesting or modifying VMs.  The `/token` route can be used to create, query, or delete tokens.  See the provided YAML configuration example, [vmpooler.yaml.example](vmpooler.yaml.example), for information on configuring an authentication store to use when performing token operations.
 
@@ -76,7 +85,7 @@ Enter host password for user 'jdoe':
 }
 ```
 
-#### VM operations
+#### VM operations <a name="vmops"></a>
 
 ##### GET /vm
 
@@ -230,7 +239,7 @@ $ curl -X DELETE --url vmpooler.company.com/api/v1/vm/fq6qlpjlsskycq6
 }
 ```
 
-#### Adding additional disk(s)
+#### Adding additional disk(s) <a name="adddisks"></a>
 
 ##### POST /vm/&lt;hostname&gt;/disk/&lt;size&gt;
 
@@ -270,7 +279,7 @@ $ curl --url vmpooler.company.com/api/v1/vm/fq6qlpjlsskycq6
 
 ````
 
-#### VM snapshots
+#### VM snapshots <a name="vmsnapshots"></a>
 
 ##### POST /vm/&lt;hostname&gt;/snapshot
 
@@ -322,7 +331,7 @@ $ curl X POST -H X-AUTH-TOKEN:a9znth9dn01t416hrguu56ze37t790bl --url vmpooler.co
 }
 ````
 
-#### Status and metrics
+#### Status and metrics <a name="statusmetrics"></a>
 
 ##### GET /status
 
@@ -541,7 +550,7 @@ $ curl -G -d 'from=2015-03-10' -d 'to=2015-03-11' --url vmpooler.company.com/api
 }
 ```
 
-#### Changing configuration via API
+#### Changing configuration via API <a name="poolconfig"></a>
 
 ##### POST /config/poolsize
 

--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -86,8 +86,8 @@ module Vmpooler
     parsed_config
   end
 
-  def self.new_redis(host = 'localhost')
-    Redis.new(host: host)
+  def self.new_redis(host = 'localhost', port = nil, password = nil)
+    Redis.new(host: host, port: port, password: password)
   end
 
   def self.new_logger(logfile)

--- a/lib/vmpooler/api/helpers.rb
+++ b/lib/vmpooler/api/helpers.rb
@@ -378,6 +378,16 @@ module Vmpooler
         result
       end
 
+      def pool_index(pools)
+        pools_hash = {}
+        index = 0
+        for pool in pools
+          pools_hash[pool['name']] = index
+          index += 1
+        end
+        pools_hash
+      end
+
     end
   end
 end

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -820,7 +820,8 @@ module Vmpooler
           invalid.each do |bad_template|
             metrics.increment("config.invalid.#{bad_template}")
           end
-          status 404
+          result[:bad_templates] = invalid
+          status 400
         end
       else
         metrics.increment('config.invalid.unknown')
@@ -846,7 +847,8 @@ module Vmpooler
           invalid.each do |bad_template|
             metrics.increment("config.invalid.#{bad_template}")
           end
-          status 404
+          result[:bad_templates] = invalid
+          status 400
         end
       else
         metrics.increment('config.invalid.unknown')
@@ -863,9 +865,12 @@ module Vmpooler
 
       if pools
         result = {
-          'ok' => true,
-          'pool configuration' => pools
+          pool_configuration: pools,
+          status: {
+            ok: true
+          }
         }
+
         status 200
       end
       JSON.pretty_generate(result)

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -855,6 +855,21 @@ module Vmpooler
 
       JSON.pretty_generate(result)
     end
+
+    get "#{api_prefix}/config/?" do
+      content_type :json
+      result = { 'ok' => false }
+      status 404
+
+      if pools
+        result = {
+          'ok' => true,
+          'pool configuration' => pools
+        }
+        status 200
+      end
+      JSON.pretty_generate(result)
+    end
   end
   end
 end

--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -631,8 +631,10 @@ module Vmpooler
                 move_vm_queue(pool['name'], next_vm, 'ready', 'completed')
               end
               if total > ready
-                $redis.smembers("vmpooler__pending__#{pool['name']}").each do |vm|
+                max_to_remove = total - pool['size']
+                $redis.smembers("vmpooler__pending__#{pool['name']}").each_with_index do |vm, i|
                   move_vm_queue(pool['name'], vm, 'pending', 'completed')
+                  if max_to_remove == (i+1) then break end
                 end
               end
             end

--- a/lib/vmpooler/providers/base.rb
+++ b/lib/vmpooler/providers/base.rb
@@ -217,6 +217,14 @@ module Vmpooler
         def vm_exists?(pool_name, vm_name)
           !get_vm(pool_name, vm_name).nil?
         end
+
+        # inputs
+        #   [Hash] pool : Configuration for the pool
+        # returns
+        #   nil when successful. Raises error when encountered
+        def create_template_delta_disks(pool)
+          raise("#{self.class.name} does not implement create_template_delta_disks")
+        end
       end
     end
   end

--- a/lib/vmpooler/providers/vsphere.rb
+++ b/lib/vmpooler/providers/vsphere.rb
@@ -197,17 +197,10 @@ module Vmpooler
             target_cluster_name = get_target_cluster_from_config(pool_name)
             target_datacenter_name = get_target_datacenter_from_config(pool_name)
 
-            # Extract the template VM name from the full path
+            # Get the template VM object
             raise("Pool #{pool_name} did not specify a full path for the template for the provider #{name}") unless template_path =~ /\//
-            templatefolders = template_path.split('/')
-            template_name = templatefolders.pop
 
-            # Get the actual objects from vSphere
-            template_folder_object = find_folder(templatefolders.join('/'), connection, target_datacenter_name)
-            raise("Pool #{pool_name} specifies a template folder of #{templatefolders.join('/')} which does not exist for the provider #{name}") if template_folder_object.nil?
-
-            template_vm_object = template_folder_object.find(template_name)
-            raise("Pool #{pool_name} specifies a template VM of #{template_name} which does not exist for the provider #{name}") if template_vm_object.nil?
+            template_vm_object = find_template_vm(pool, connection)
 
             # Annotate with creation time, origin template, etc.
             # Add extraconfig options that can be queried by vmtools
@@ -963,6 +956,30 @@ module Vmpooler
           folder_object = dc.vmFolder.traverse(new_folder, type=RbVmomi::VIM::Folder, create=true)
           raise("Cannot create folder #{new_folder}") if folder_object.nil?
           folder_object
+        end
+
+        def find_template_vm(pool, connection)
+          datacenter = get_target_datacenter_from_config(pool['name'])
+          raise('cannot find datacenter') if datacenter.nil?
+
+          propSpecs = {
+            :entity => self,
+            :inventoryPath => "#{datacenter}/vm/#{pool['template']}"
+          }
+
+          template_vm_object = connection.searchIndex.FindByInventoryPath(propSpecs)
+          raise("Pool #{pool['name']} specifies a template VM of #{pool['template']} which does not exist for the provider #{name}") if template_vm_object.nil?
+
+          template_vm_object
+        end
+
+        def create_template_delta_disks(pool)
+          @connection_pool.with_metrics do |pool_object|
+            connection = ensured_vsphere_connection(pool_object)
+            template_vm_object = find_template_vm(pool, connection)
+
+            template_vm_object.add_delta_disk_layer_on_all_disks
+          end
         end
       end
     end

--- a/spec/integration/api/v1/config_spec.rb
+++ b/spec/integration/api/v1/config_spec.rb
@@ -156,5 +156,12 @@ describe Vmpooler::API::V1 do
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
       end
     end
+
+    describe 'GET /config' do
+      it 'returns pool configuration when set' do
+        get "#{prefix}/config"
+        expect_json(ok = true, http = 200)
+      end
+    end
   end
 end

--- a/spec/integration/api/v1/config_spec.rb
+++ b/spec/integration/api/v1/config_spec.rb
@@ -18,24 +18,25 @@ describe Vmpooler::API::V1 do
     Vmpooler::API
   end
 
+  let(:config) {
+    {
+      config: {
+        'site_name' => 'test pooler',
+        'vm_lifetime_auth' => 2,
+      },
+      pools: [
+        {'name' => 'pool1', 'size' => 5, 'template' => 'templates/pool1'},
+        {'name' => 'pool2', 'size' => 10}
+      ],
+      statsd: { 'prefix' => 'stats_prefix'},
+      alias: { 'poolone' => 'pool1' },
+      pool_names: [ 'pool1', 'pool2', 'poolone' ]
+    }
+  }
+
   describe '/config/pooltemplate' do
     let(:prefix) { '/api/v1' }
     let(:metrics) { Vmpooler::DummyStatsd.new }
-    let(:config) {
-      {
-        config: {
-          'site_name' => 'test pooler',
-          'vm_lifetime_auth' => 2,
-        },
-        pools: [
-          {'name' => 'pool1', 'size' => 5, 'template' => 'templates/pool1'},
-          {'name' => 'pool2', 'size' => 10}
-        ],
-        statsd: { 'prefix' => 'stats_prefix'},
-        alias: { 'poolone' => 'pool1' },
-        pool_names: [ 'pool1', 'pool2', 'poolone' ]
-      }
-    }
 
     let(:current_time) { Time.now }
 
@@ -170,15 +171,6 @@ describe Vmpooler::API::V1 do
 
     describe 'GET /config' do
       let(:prefix) { '/api/v1' }
-      let(:config) {
-        {
-          config: {},
-          pools: [
-            {'name' => 'pool1', 'size' => 5, 'template' => 'templates/pool1'},
-            {'name' => 'pool2', 'size' => 10}
-          ],
-        }
-      }
 
       it 'returns pool configuration when set' do
         get "#{prefix}/config"

--- a/spec/integration/api/v1/config_spec.rb
+++ b/spec/integration/api/v1/config_spec.rb
@@ -1,0 +1,160 @@
+require 'spec_helper'
+require 'rack/test'
+
+module Vmpooler
+  class API
+    module Helpers
+      def authenticate(auth, username_str, password_str)
+        username_str == 'admin' and password_str == 's3cr3t'
+      end
+    end
+  end
+end
+
+describe Vmpooler::API::V1 do
+  include Rack::Test::Methods
+
+  def app()
+    Vmpooler::API
+  end
+
+  describe '/config/pooltemplate' do
+    let(:prefix) { '/api/v1' }
+    let(:metrics) { Vmpooler::DummyStatsd.new }
+    let(:config) {
+      {
+        config: {
+          'site_name' => 'test pooler',
+          'vm_lifetime_auth' => 2,
+        },
+        pools: [
+          {'name' => 'pool1', 'size' => 5, 'template' => 'templates/pool1'},
+          {'name' => 'pool2', 'size' => 10}
+        ],
+        statsd: { 'prefix' => 'stats_prefix'},
+        alias: { 'poolone' => 'pool1' },
+        pool_names: [ 'pool1', 'pool2', 'poolone' ]
+      }
+    }
+
+    let(:current_time) { Time.now }
+
+    before(:each) do
+      redis.flushdb
+
+      app.settings.set :config, config
+      app.settings.set :redis, redis
+      app.settings.set :metrics, metrics
+      app.settings.set :config, auth: false
+      create_token('abcdefghijklmnopqrstuvwxyz012345', 'jdoe', current_time)
+    end
+
+    describe 'POST /config/pooltemplate' do
+      it 'updates a pool template' do
+        post "#{prefix}/config/pooltemplate", '{"pool1":"templates/new_template"}'
+        expect_json(ok = true, http = 201)
+
+        expected = { ok: true }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+      end
+
+      it 'fails on nonexistent pools' do
+        post "#{prefix}/config/pooltemplate", '{"poolpoolpool":"templates/newtemplate"}'
+        expect_json(ok = false, http = 404)
+      end
+
+      it 'updates multiple pools' do
+        post "#{prefix}/config/pooltemplate", '{"pool1":"templates/new_template","pool2":"templates/new_template2"}'
+        expect_json(ok = true, http = 201)
+
+        expected = { ok: true }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+      end
+
+      it 'fails when not all pools exist' do
+        post "#{prefix}/config/pooltemplate", '{"pool1":"templates/new_template","pool3":"templates/new_template2"}'
+        expect_json(ok = false, http = 404)
+
+        expected = { ok: false }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+      end
+
+      it 'returns no changes when the template does not change' do
+        post "#{prefix}/config/pooltemplate", '{"pool1":"templates/pool1"}'
+        expect_json(ok = true, http = 200)
+
+        expected = { ok: true }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+      end
+
+      it 'fails when a invalid template parameter is provided' do
+        post "#{prefix}/config/pooltemplate", '{"pool1":"template1"}'
+        expect_json(ok = false, http = 404)
+
+        expected = { ok: false }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+      end
+    end
+
+    describe 'POST /config/poolsize' do
+      it 'changes a pool size' do
+        post "#{prefix}/config/poolsize", '{"pool1":"2"}'
+        expect_json(ok = true, http = 201)
+
+        expected = { ok: true }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+      end
+
+      it 'changes a pool size for multiple pools' do
+        post "#{prefix}/config/poolsize", '{"pool1":"2","pool2":"2"}'
+        expect_json(ok = true, http = 201)
+
+        expected = { ok: true }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+      end
+
+      it 'fails when a specified pool does not exist' do
+        post "#{prefix}/config/poolsize", '{"pool10":"2"}'
+        expect_json(ok = false, http = 404)
+
+        expected = { ok: false }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+      end
+
+      it 'succeeds with 200 when no change is required' do
+        post "#{prefix}/config/poolsize", '{"pool1":"5"}'
+        expect_json(ok = true, http = 200)
+
+        expected = { ok: true }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+      end
+
+      it 'succeeds with 201 when at least one pool changes' do
+        post "#{prefix}/config/poolsize", '{"pool1":"5","pool2":"5"}'
+        expect_json(ok = true, http = 201)
+
+        expected = { ok: true }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+      end
+
+      it 'fails when a non-integer value is provided for size' do
+        post "#{prefix}/config/poolsize", '{"pool1":"four"}'
+        expect_json(ok = false, http = 404)
+
+        expected = { ok: false }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+      end
+    end
+  end
+end

--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -1669,7 +1669,18 @@ EOT
 
         subject.remove_excess_vms(config[:pools][0], provider, 2, 5)
       end
+
+      it 'should remove excess pending vms, but only the excess' do
+        create_pending_vm(pool,'vm1')
+        create_pending_vm(pool,'vm2')
+        create_pending_vm(pool,'vm3')
+        create_pending_vm(pool,'vm4')
+        expect(subject).to receive(:move_vm_queue).exactly(3).times
+
+        subject.remove_excess_vms(config[:pools][0], provider, 1, 5)
+      end
     end
+
   end
 
   describe 'prepare_template' do

--- a/vmpooler
+++ b/vmpooler
@@ -7,13 +7,15 @@ require 'lib/vmpooler'
 
 config = Vmpooler.config
 redis_host = config[:redis]['server']
+redis_port = config[:redis]['port']
+redis_password = config[:redis]['password']
 logger_file = config[:config]['logfile']
 
 metrics = Vmpooler.new_metrics(config)
 
 api = Thread.new do
   thr = Vmpooler::API.new
-  thr.helpers.configure(config, Vmpooler.new_redis(redis_host), metrics)
+  thr.helpers.configure(config, Vmpooler.new_redis(redis_host, redis_port, redis_password), metrics)
   thr.helpers.execute!
 end
 
@@ -21,7 +23,7 @@ manager = Thread.new do
   Vmpooler::PoolManager.new(
     config,
     Vmpooler.new_logger(logger_file),
-    Vmpooler.new_redis(redis_host),
+    Vmpooler.new_redis(redis_host, redis_port, redis_password),
     metrics
   ).execute!
 end


### PR DESCRIPTION
Before this fix, if the pool had an excessive number of 'pending' vms,
but was not full of 'ready' vms, we would end up clearing all the
'pending' vms regardless, which could bring us back under the max
pool size. This fix makes sure we only remove the excess, see
unit test for an example